### PR TITLE
Implement financial change request approvals

### DIFF
--- a/components/navbar-top.tsx
+++ b/components/navbar-top.tsx
@@ -30,16 +30,21 @@ export function TopNavbar() {
 				label: 'Rol Yönetimi',
 				roles: ['admin'],
 			},
-			{
-				href: '/admin/branches',
-				label: 'Şube Yönetimi',
-				roles: ['admin', 'manager'],
-			},
-			{
-				href: '/admin/financial-logs',
-				label: 'Finansal Kayıtlar',
-				roles: ['admin'],
-			},
+                        {
+                                href: '/admin/branches',
+                                label: 'Şube Yönetimi',
+                                roles: ['admin', 'manager'],
+                        },
+                        {
+                                href: '/admin/financial-approvals',
+                                label: 'Finansal Onaylar',
+                                roles: ['admin', 'manager'],
+                        },
+                        {
+                                href: '/admin/financial-logs',
+                                label: 'Finansal Kayıtlar',
+                                roles: ['admin'],
+                        },
 		],
 		[]
 	);


### PR DESCRIPTION
## Summary
- add financial change request approval page for admins and managers
- show new **Finansal Onaylar** menu item
- branch staff now submits change requests when editing existing data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866d6b059e48320a512f6e8d1525a2b