### PR TITLE
Fix profile updates and rename settings page

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -52,7 +52,7 @@ export default function PrivatePage() {
                         setLoading(false);
                 };
 		getUser();
-	}, [router, supabase.auth]);
+	}, [router, supabase, supabase.auth]);
 
         const handleProfileUpdate = async (e: FormEvent) => {
                 e.preventDefault();
@@ -65,7 +65,7 @@ export default function PrivatePage() {
                 if (fullName.trim() !== '') {
                         const parts = fullName.trim().split(' ');
                         profileUpdates.first_name = parts.shift() || '';
-                        profileUpdates.last_name = parts.join(' ') || null;
+                        profileUpdates.last_name = parts.join(' ') || '';
                 }
 
                 const userUpdateData: { phone?: string } = {};

--- a/components/user-status.tsx
+++ b/components/user-status.tsx
@@ -82,8 +82,8 @@ export function UserStatus() {
 					</button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent className="w-40" align="end">
-					<DropdownMenuItem asChild>
-						<Link href="/private">
+                                        <DropdownMenuItem asChild>
+                                                <Link href="/settings">
 							<div className="flex items-center">
 								<SettingsIcon className="mr-2 h-4 w-4" />
 								Ayarlar

--- a/middleware.ts
+++ b/middleware.ts
@@ -163,7 +163,7 @@ export async function middleware(request: NextRequest) {
 			'/admin/branch-financials',
 			'/admin/financial-approvals',
 			'/admin/financial-logs',
-			'/private',
+                        '/settings',
 			'/branch/',
 		];
 		if (
@@ -200,7 +200,7 @@ export async function middleware(request: NextRequest) {
 		}
 		const isAtOwnBranchPage =
 			staffBranchId && pathname === `/branch/${staffBranchId}`;
-		const isAtPrivate = pathname.startsWith('/private');
+                const isAtPrivate = pathname.startsWith('/settings');
 		const isAtRoot = pathname === '/';
 		const isAtRequests = pathname === '/my-change-requests';
 		if (isAtOwnBranchPage || isAtPrivate || isAtRoot || isAtRequests) {
@@ -223,7 +223,7 @@ export async function middleware(request: NextRequest) {
 	}
 
 	if (userRole === 'user') {
-		const allowedUserPaths = ['/authorization-pending', '/private', '/'];
+                const allowedUserPaths = ['/authorization-pending', '/settings', '/'];
 		if (allowedUserPaths.includes(pathname)) {
 			return response;
 		}


### PR DESCRIPTION
## Summary
- move private page to `/settings` and update all links
- update access control middleware to handle `/settings`
- ensure profile names are read from Supabase `profiles` table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869447216e083208497576bb1664246