### PR TITLE
Fix branch staff dashboard redirect loop

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -120,12 +120,13 @@ const LOCAL_STORAGE_PRESET_KEY = 'lastSelectedPreset';
 function DashboardContent() {
 	const router = useRouter();
 	const searchParams = useSearchParams();
-	const {
-		user,
-		role: userRoleFromAuth, // userRole olarak yeniden adlandırıldı
-		loading: authLoading,
-		error: authError,
-	} = useAuth();
+        const {
+                user,
+                role: userRoleFromAuth, // userRole olarak yeniden adlandırıldı
+                staffBranchId,
+                loading: authLoading,
+                error: authError,
+        } = useAuth();
 	const today = startOfDay(new Date());
 
 	const currentSelectedDateRangeRef = useRef<DateRange | undefined>(undefined);
@@ -217,12 +218,20 @@ function DashboardContent() {
 				router.push('/login?message=Giriş yapmanız gerekiyor.');
 				return;
 			}
-			if (userRoleFromAuth !== 'admin' && userRoleFromAuth !== 'manager') {
-				router.push('/?message=Bu sayfaya erişim yetkiniz yok.');
-				return;
-			}
+                        if (userRoleFromAuth !== 'admin' && userRoleFromAuth !== 'manager') {
+                                if (userRoleFromAuth === 'branch_staff') {
+                                        if (staffBranchId) {
+                                                router.push(`/branch/${staffBranchId}`);
+                                        } else {
+                                                router.push('/authorization-pending');
+                                        }
+                                } else {
+                                        router.push('/?message=Bu sayfaya erişim yetkiniz yok.');
+                                }
+                                return;
+                        }
 		}
-	}, [user, userRoleFromAuth, authLoading, authError, router]);
+        }, [user, userRoleFromAuth, staffBranchId, authLoading, authError, router]);
 
 	useEffect(() => {
 		currentSelectedDateRangeRef.current = selectedDateRange;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,11 +21,11 @@ export default function Home() {
 				return;
 			}
 
-			const { data, error } = await supabase
-				.from('profiles')
-				.select('role')
-				.eq('id', user.id)
-				.single();
+                        const { data, error } = await supabase
+                                .from('profiles')
+                                .select('role, staff_branch_id')
+                                .eq('id', user.id)
+                                .single();
 
 			if (error || !data) {
 				console.error('Error fetching profile:', error);
@@ -36,11 +36,17 @@ export default function Home() {
 
                         const userRole = data.role;
 
-			if (userRole === 'user') {
-				router.push('/authorization-pending');
-			} else {
-				router.push('/dashboard');
-			}
+                        if (userRole === 'user') {
+                                router.push('/authorization-pending');
+                        } else if (userRole === 'branch_staff') {
+                                if (data.staff_branch_id) {
+                                        router.push(`/branch/${data.staff_branch_id}`);
+                                } else {
+                                        router.push('/authorization-pending');
+                                }
+                        } else {
+                                router.push('/dashboard');
+                        }
 			setLoading(false);
 		}
 		fetchRole();


### PR DESCRIPTION
## Summary
- ensure root page redirects branch_staff users directly to their branch
- redirect branch staff away from `/dashboard` inside the dashboard page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b8d77f5908320aca6ea04e315c592