### PR TITLE
⚡ [performance] Resolve N+1 query in financial logs enrichment

### DIFF
--- a/app/admin/financial-logs/page.tsx
+++ b/app/admin/financial-logs/page.tsx
@@ -53,30 +53,31 @@ export default function FinancialLogsPage() {
         return;
       }
 
-      // 2. Verileri zenginleştir
-      const enrichedLogs = await Promise.all(
-        logData.map(async (log) => {
-          const [branchResponse, userResponse] = await Promise.all([
-            supabase
-              .from('branches')
-              .select('name')
-              .eq('id', log.branch_id)
-              // .eq('archived', false)
-              .single(),
-            supabase
-              .from('profiles')
-              .select('email')
-              .eq('id', log.user_id)
-              .single(),
-          ]);
+      // 2. Verileri zenginleştir (N+1 sorgusunu çözmek için toplu sorgu)
+      const branchIds = [...new Set(logData.map((log) => log.branch_id).filter(Boolean))];
+      const userIds = [...new Set(logData.map((log) => log.user_id).filter(Boolean))];
 
-          return {
-            ...log,
-            branchName: branchResponse.data?.name || 'Bilinmiyor',
-            userEmail: userResponse.data?.email || 'Bilinmiyor',
-          };
-        })
+      const [branchesResponse, usersResponse] = await Promise.all([
+        branchIds.length > 0
+          ? supabase.from('branches').select('id, name').in('id', branchIds)
+          : Promise.resolve({ data: [] }),
+        userIds.length > 0
+          ? supabase.from('profiles').select('id, email').in('id', userIds)
+          : Promise.resolve({ data: [] }),
+      ]);
+
+      const branchesMap = new Map(
+        (branchesResponse.data || []).map((b: any) => [b.id, b.name])
       );
+      const usersMap = new Map(
+        (usersResponse.data || []).map((u: any) => [u.id, u.email])
+      );
+
+      const enrichedLogs = logData.map((log) => ({
+        ...log,
+        branchName: branchesMap.get(log.branch_id) || 'Bilinmiyor',
+        userEmail: usersMap.get(log.user_id) || 'Bilinmiyor',
+      }));
 
       setLogs(enrichedLogs);
 


### PR DESCRIPTION
💡 **What:** Replaced the `Promise.all` `.map()` approach which was individually querying the `branches` and `profiles` tables for every single financial log. The optimization extracts unique IDs using a `Set`, executes exactly two batch queries via Supabase's `.in()` filter (one for branches, one for users), and then builds an in-memory `Map` to enrich the logs.

🎯 **Why:** The previous code suffered from a classic N+1 query issue. If 50 logs were loaded, it would make 1 query for the logs, and then 100 separate queries (50 branches + 50 profiles) to the database, consuming connections and introducing latency.

📊 **Measured Improvement:** Establishing a live runtime performance benchmark was impractical as the sandbox lacks network access for `npm install` and `node_modules` is not pre-installed. However, this fix theoretically guarantees a massive reduction in queries from `O(N)` to exactly `O(1)`. Specifically, instead of executing `1 + 2N` queries, this code now strictly executes exactly `3` database queries regardless of the number of logs fetched, guaranteeing a highly scalable improvement as log history grows.

---
*PR created automatically by Jules for task [8363812899673092605](https://jules.google.com/task/8363812899673092605) started by @bariszerk*