### PR TITLE
🔒 Fix Missing Type Validation on Address in Branch Creation

### DIFF
--- a/app/api/branch/route.test.ts
+++ b/app/api/branch/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, mock } from 'bun:test';
+
+// Helper to create a chainable mock
+const createChainableMock = () => {
+  const m: any = mock(() => m);
+  m.single = mock(() => Promise.resolve({ data: null, error: null }));
+  m.maybeSingle = mock(() => Promise.resolve({ data: null, error: null }));
+  m.select = mock(() => m);
+  m.eq = mock(() => m);
+  m.insert = mock(() => m);
+  return m;
+};
+
+// Mock Supabase client
+const mockSupabase = {
+  auth: {
+    getUser: mock(() => Promise.resolve({ data: { user: { id: 'admin-id' } } })),
+  },
+  from: mock((table: string) => {
+    const chain = createChainableMock();
+    if (table === 'profiles') {
+      chain.single = mock(() => Promise.resolve({ data: { role: 'admin' }, error: null }));
+    } else if (table === 'branches') {
+      // Mock for insert(...).select().single()
+      chain.single = mock(() => Promise.resolve({ data: { id: 'new-id' }, error: null }));
+    }
+    return chain;
+  }),
+};
+
+mock.module('@/utils/supabase/server', () => ({
+  createClient: mock(() => Promise.resolve(mockSupabase)),
+}));
+
+mock.module('next/server', () => ({
+  NextResponse: {
+    json: mock((data: any, init?: any) => ({
+      status: init?.status || 200,
+      json: async () => data,
+    })),
+  },
+}));
+
+// Use dynamic import to ensure mocks are applied
+const { POST } = await import('./route');
+
+describe('POST /api/branch', () => {
+  it('returns 400 when address is not a string', async () => {
+    const requestBody = {
+      name: 'New Branch',
+      address: { city: 'London' }, // Non-string address
+    };
+
+    const request = new Request('http://localhost/api/branch', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const result = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result.message).toBe('Geçersiz adres formatı.');
+  });
+
+  it('successfully creates a branch with a string address', async () => {
+    const requestBody = {
+      name: 'New Branch',
+      address: '123 Street',
+    };
+
+    const request = new Request('http://localhost/api/branch', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const result = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(result.id).toBe('new-id');
+  });
+
+  it('successfully creates a branch without an address', async () => {
+    const requestBody = {
+      name: 'New Branch',
+    };
+
+    const request = new Request('http://localhost/api/branch', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const result = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(result.id).toBe('new-id');
+  });
+});

--- a/app/api/branch/route.ts
+++ b/app/api/branch/route.ts
@@ -36,6 +36,10 @@ export async function POST(request: Request) {
         return NextResponse.json({ message: 'Şube adı gereklidir.' }, { status: 400 });
     }
 
+    if (address !== undefined && address !== null && typeof address !== 'string') {
+        return NextResponse.json({ message: 'Geçersiz adres formatı.' }, { status: 400 });
+    }
+
     // Aynı isimde başka bir şube olup olmadığını kontrol et
   const { data: existingBranch, error: checkError } = await supabase
         .from('branches')
@@ -57,7 +61,7 @@ export async function POST(request: Request) {
         .from('branches')
         .insert([{
             name: name.trim(),
-            address: address ? address.trim() : null,
+            address: (address && typeof address === 'string') ? address.trim() : null,
         }])
         .select()
         .single();


### PR DESCRIPTION
🎯 **What:** Added type validation for the `address` field in the branch creation API (`app/api/branch/route.ts`).

⚠️ **Risk:** Previously, providing a non-string truthy value (e.g., an object or array) for `address` would cause an unhandled `TypeError` when calling `.trim()`, resulting in a 500 Internal Server Error and potentially exposing server-side details or impacting service availability.

🛡️ **Solution:** 
- Implemented an explicit check to ensure `address` is a string if it is not null or undefined.
- Updated the insertion logic to safely call `.trim()` only when `address` is a valid string.
- Added a new unit test suite `app/api/branch/route.test.ts` to verify the fix and ensure proper handling of various input types.

---
*PR created automatically by Jules for task [16063201099234208401](https://jules.google.com/task/16063201099234208401) started by @bariszerk*